### PR TITLE
add error messages, change cryptoOptions to be on encrypt method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ _Note: dexie-encrypted creates a database table to hold its configuration so you
 
 ```javascript
 import Dexie from 'dexie';
-import encrypt, { cryptoOptions } from 'dexie-encrypted';
+import encrypt from 'dexie-encrypted';
 
 const db = new Dexie('MyDatabase');
 
 // set the key and provide a configuration of how to encrypt at a table level.
 encrypt(db, symmetricKey, {
-    friends: cryptoOptions.NON_INDEXED_FIELDS,
+    friends: encrypt.NON_INDEXED_FIELDS,
 });
 
 // If this is the first time you've encrypted bump the version number.
@@ -52,19 +52,19 @@ encrypt(db, key, config);
 
 Dexie-encrypted can be configured to encrypt all the data of a table, to whitelist fields that are non-sensitive, or to blacklist sensitive fields.
 
--   `cryptoOptions.NON_INDEXED_FIELDS` - all data other than indices will be encrypted.
--   `cryptoOptions.WHITELIST` - all data other than indices and whitelisted fields will be encrypted.
--   `cryptoOptions.BLACKLIST` - listed fields will be encrypted.
+-   `encrypt.NON_INDEXED_FIELDS` - all data other than indices will be encrypted.
+-   `encrypt.WHITELIST` - all data other than indices and whitelisted fields will be encrypted.
+-   `encrypt.BLACKLIST` - listed fields will be encrypted.
 
 ```javascript
 encrypt(db, symmetricKey, {
-    users: cryptoOptions.NON_INDEXED_FIELDS,
+    users: encrypt.NON_INDEXED_FIELDS,
     friends: {
-        type: cryptoOptions.WHITELIST,
+        type: encrypt.WHITELIST,
         fields: ['street', 'picture'], // these two fields and indices will be plain text
     },
     enemies: {
-        type: cryptoOptions.BLACKLIST,
+        type: encrypt.BLACKLIST,
         fields: ['picture', 'isMortalEnemy'], // note: these cannot be indices
     },
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,6 +91,11 @@ function hideValue(input) {
 }
 
 function encrypt(db, key, cryptoSettings, nonceOverride) {
+
+    if ((key instanceof Uint8Array) === false || key.length !== 32) {
+        throw new Error('Dexie-encrypted requires a UInt8Array of length 32 for a encryption key.');
+    }
+
     db.Version.prototype._parseStoresSpec = override(
         db.Version.prototype._parseStoresSpec,
         overrideParseStoresSpec
@@ -184,7 +189,16 @@ function encrypt(db, key, cryptoSettings, nonceOverride) {
                                 return;
                             }
                             table.hook('creating', function(primKey, obj) {
+                                const preservedValue = {...obj};
                                 encryptWithRule(table, obj, newSetting);
+                                this.onsuccess = () => {
+                                    delete obj.__encryptedData;
+                                    Object.assign(obj, preservedValue);
+                                };
+                                this.onerror = () => {
+                                    delete obj.__encryptedData;
+                                    Object.assign(obj, preservedValue);
+                                };
                             });
                             table.hook('updating', function(modifications, primKey, obj) {
                                 return encryptWithRule(table, { ...obj }, newSetting);
@@ -234,6 +248,8 @@ function encrypt(db, key, cryptoSettings, nonceOverride) {
             });
     });
 }
+
+Object.assign(encrypt, cryptoOptions);
 
 exports.cryptoOptions = cryptoOptions;
 exports.default = encrypt;


### PR DESCRIPTION
* This makes the library throw an error if your key is not a 32 bit Uint8Array.
* removes the cryptoOptions enum, instead putting it directly on the function.
* Fix bug where your object would be stripped of values when it's stored.
