### PR TITLE
Prevent encrypting all fields when not necessary

### DIFF
--- a/src/installHooks.ts
+++ b/src/installHooks.ts
@@ -63,7 +63,7 @@ export function encryptEntity<T extends Dexie.Table>(
     }
 
     // @ts-ignore
-    dataToStore.__encryptedData = performEncryption(encryptionKey, entity, nonceOverride);
+    dataToStore.__encryptedData = performEncryption(encryptionKey, toEncrypt, nonceOverride);
     return dataToStore;
 }
 


### PR DESCRIPTION
This change shouldn't have any functional effect, this is mainly preventing performance degradation (imagine having table with ArrayBuffer field with a lot of data, not configured to be encrypted, but in fact being encrypted due to this performance bug).